### PR TITLE
Add conda devenv as environment management option

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -34,7 +34,7 @@ jobs:
           conda update -q conda
           conda info -a
           conda devenv
-          conda activate blank-project
+          source activate blank-project
       - name: pre-commit Checkers and Formatters
         shell: bash -l {0}
         run: |

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -14,10 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup conda
@@ -46,8 +43,3 @@ jobs:
         run: |
           source activate blank-project
           pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.3
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.xml

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: goanpeca/setup-miniconda@v1.0.2
-        with:
-          auto-update-conda: true
+      with:
+        auto-update-conda: true
     - name: Configure conda
       shell: bash -l {0}
       run: |

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -19,15 +19,12 @@ jobs:
     strategy:
       max-parallel: 4
       fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: goanpeca/setup-miniconda@v1.0.2
         with:
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
     - name: Configure conda
       shell: bash -l {0}
       run: |
@@ -37,10 +34,10 @@ jobs:
         conda update -q conda
         conda info -a
         conda devenv
-        source activate blank-project
     - name: pre-commit Checkers and Formatters
       shell: bash -l {0}
       run: |
+        source activate blank-project
         pre-commit install
         pre-commit run --all-files
     - name: Test with pytest

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,4 +1,4 @@
-name: linux
+name: devenv
 
 on:
   push:

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Test with pytest
       shell: bash -l {0}
       run: |
+        source activate blank-project
         pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.3

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,0 +1,54 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+  schedule:
+  - cron: "0 5 * * 1"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+    - name: Configure conda
+      shell: bash -l {0}
+      run: |
+        conda config --set always_yes yes --set changeps1 no
+        conda config --add channels conda-forge
+        conda install conda-devenv
+        conda update -q conda
+        conda info -a
+        conda devenv
+        source activate blank-project
+    - name: pre-commit Checkers and Formatters
+      shell: bash -l {0}
+      run: |
+        pre-commit install
+        pre-commit run --all-files
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.xml

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -33,7 +33,7 @@ jobs:
           conda update -q conda
           conda info -a
           conda devenv
-          source activate blank-project
+          conda activate blank-project
       - name: pre-commit Checkers and Formatters
         run: |
           pre-commit install

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -14,39 +14,35 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
-      fail-fast: false
-
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
-    - uses: goanpeca/setup-miniconda@v1.0.2
-      with:
-        auto-update-conda: true
-    - name: Configure conda
-      shell: bash -l {0}
-      run: |
-        conda config --set always_yes yes --set changeps1 no
-        conda config --add channels conda-forge
-        conda install conda-devenv
-        conda update -q conda
-        conda info -a
-        conda devenv
-    - name: pre-commit Checkers and Formatters
-      shell: bash -l {0}
-      run: |
-        source activate blank-project
-        pre-commit install
-        pre-commit run --all-files
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        source activate blank-project
-        pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
+      - uses: actions/checkout@v2
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          conda-channels: conda-forge
+      - run: conda --version
+      - name: Configure conda-devenv
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda install conda-devenv
+          conda update -q conda
+          conda info -a
+          conda devenv
+          source activate blank-project
+      - name: pre-commit Checkers and Formatters
+        run: |
+          pre-commit install
+          pre-commit run --all-files
+      - name: Test with pytest
+        run: |
+          pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./coverage.xml

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -38,11 +38,13 @@ jobs:
       - name: pre-commit Checkers and Formatters
         shell: bash -l {0}
         run: |
+          source activate blank-project
           pre-commit install
           pre-commit run --all-files
       - name: Test with pytest
         shell: bash -l {0}
         run: |
+          source activate blank-project
           pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.3

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -27,6 +27,7 @@ jobs:
           conda-channels: conda-forge
       - run: conda --version
       - name: Configure conda-devenv
+        shell: bash -l {0}
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda install conda-devenv
@@ -35,10 +36,12 @@ jobs:
           conda devenv
           conda activate blank-project
       - name: pre-commit Checkers and Formatters
+        shell: bash -l {0}
         run: |
           pre-commit install
           pre-commit run --all-files
       - name: Test with pytest
+        shell: bash -l {0}
         run: |
           pytest . --cov-config=.coveragerc --cov-report=xml --cov=mypackage
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ the development of a Python project based on a minimal working structure.
 * [Travis CI](https://travis-ci.com) minimal configuration;
 * [GitHub Actions](https://github.com/features/actions) workflows with minimal configurations for latest Ubuntu, macOS and Windows;
 * Tests with [pytest](https://docs.pytest.org/en/latest/);
+* Development environment with two options:
+    * The classic [virtualenv](https://virtualenv.pypa.io/en/latest/)
+    * A [conda](https://conda.io/en/latest/) environment with [conda-devenv](https://github.com/ESSS/conda-devenv) extension
 * Hierarchical structure to a python package as suggested by ["The Hitchhiker’s Guide to Python"](https://docs.python-guide.org/) (highly recommended reading);
 * A [Read The Docs](https://readthedocs.org/) configuration scratch;
 * [pre-commit](https://pre-commit.com/) to perform git hooks before commits. The following plugins are being used:

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,0 +1,27 @@
+name: blank-project
+channels:
+  - conda-forge
+dependencies:
+  # Python stack
+  - python>=3.6
+  - black
+  - numpy>=1.13.3
+  - pytest>=3.8.0
+  - scipy>=1.1.0
+
+  # For tests
+  - pytest>=3.8.0
+  - pytest-cov
+  - pytest-xdist
+  - codecov
+
+  # For documentation
+  - sphinx
+  - sphinx_rtd_theme
+
+  # Hooks for git
+  - pre-commit
+
+environment:
+  PYTHONPATH:
+    - {{ root }}


### PR DESCRIPTION
This PR adds the nice tool [conda-devenv](https://github.com/ESSS/conda-devenv) as an alternative for classic Python `virtualenv`. It enables the use of [conda](https://conda.io/en/latest/) environments.