### PR TITLE
Allow publish-docs workflow to be triggered on demand

### DIFF
--- a/.github/workflows/conda-lock-update.yml
+++ b/.github/workflows/conda-lock-update.yml
@@ -3,7 +3,7 @@ name: Update conda-lock
 on:
   schedule:
     - cron: "0 3 * * 1"  # runs at 03:00 UTC on Mondays
-  # This workflow can also be trigged on demand
+  # This workflow can also be triggered on demand
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  # This workflow can also be triggered on demand
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Also, fix a minor typo in conda-lock-update.yml.